### PR TITLE
Sections fixes and and enhancements

### DIFF
--- a/script/mct/modules/option_obj.lua
+++ b/script/mct/modules/option_obj.lua
@@ -172,9 +172,7 @@ function mct_option:set_assigned_section(section_key)
         return false
     end
 
-    section:assign_option(self)
-
-    self._assigned_section = section_key
+    section:assign_option(self) -- this sets the option's self._assigned_section
 end
 
 --- Reads the assigned_section for this option.

--- a/script/mct/modules/section_obj.lua
+++ b/script/mct/modules/section_obj.lua
@@ -365,7 +365,7 @@ function mct_section:assign_option(option_obj)
     -- remove this option from any previous section it was assigned to
     local old_assignment = option_obj:get_assigned_section()
     if old_assignment then
-        local old_section = current_mod:get_sections()[old_assignment]
+        local old_section = current_mod:get_section_by_key(old_assignment)
         if old_section then
             old_section._options[option_key] = nil
         end

--- a/script/mct/modules/ui.lua
+++ b/script/mct/modules/ui.lua
@@ -760,11 +760,15 @@ function ui_obj:create_sections_and_contents(mod_obj)
     --self._sections_to_rows = {}
 
     core:remove_listener("MCT_SectionHeaderPressed")
+    
+    local ordered_section_keys = mod_obj:sort_sections()
 
-    for section_key, section_obj in pairs(sections) do
+    for i, section_key in ipairs(ordered_section_keys) do
         --local section_table = sections[i]
         --local section_key = section_table.key
         --self._sections_to_rows[section_key] = {}
+        
+        local section_obj = mod_obj:get_section_by_key(section_key);
 
         -- make sure the dummy rows table is clear before doing anything
         section_obj._dummy_rows = {}


### PR DESCRIPTION
- Fixes a bug that results in an option being added to multiple sections when it was assigned to any section besides mod_obj._last_section or when it was reassigned to another section.
- Fixes an error in the example function above `mct_section:set_option_sort_function`
- By default, now sorts sections by section_key instead of displaying sections in an arbitrary according to pairs() iteration
- Adds support for sorting sections by "key_sort", "index_sort", or a modder-supplied function